### PR TITLE
chore: remove @jonasperes from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @JonasPeres @squidit-master
+* @squidit-master


### PR DESCRIPTION
## Summary

Remove @jonasperes from CODEOWNERS as part of offboarding / access cleanup.

## Checklist

- [ ] Review that remaining code owners are correct
- [ ] Merge when approved
